### PR TITLE
Fix of a permission denied error caused by delay of GPIO pin exporting.

### DIFF
--- a/src/PhpGpio/Gpio.php
+++ b/src/PhpGpio/Gpio.php
@@ -98,6 +98,9 @@ class Gpio implements GpioInterface
         // Export pin
         file_put_contents(GpioInterface::PATH_EXPORT, $pinNo);
 
+	// wait until pin is ready
+	while(!is_writable(GpioInterface::PATH_GPIO.$pinNo)) { /* empty */ }
+
         // if valid direction then set direction
         if ($this->isValidDirection($direction)) {
             file_put_contents(GpioInterface::PATH_GPIO.$pinNo.'/direction', $direction);


### PR DESCRIPTION
When I use Gpio class directly from webpage (for example from _index.php_ file through Apache) it return me a _Permission dennied_ error. I have found out that it was caused by delay (around 0.04s) when the _setup_ method exported GPIO pin.
